### PR TITLE
Adjust publishing folders in Action workflow and move header tags

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -23,6 +23,6 @@ jobs:
         - name: Deploy
           uses: peaceiris/actions-gh-pages@v3
           with:
-            deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-            publish_dir: ./public
-            publish_branch: main
+            deploy_key: ${{ secrets.GITHUB_TOKEN }}
+            publish_dir: docs
+            publish_branch: gh-pages

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,4 +1,3 @@
-<header class="site-header fixed-top">
 
 <div class="container-fluid"> {# Apply full-width #}
 <nav class="navbar navbar-expand-lg navbar-light">
@@ -32,5 +31,3 @@
 
 </nav>
 </div>
-
-</header>

--- a/src/_includes/page.njk
+++ b/src/_includes/page.njk
@@ -11,7 +11,7 @@
 
 <body>
 
-<header>
+<header class="site-header fixed-top">
 {% include "header.njk" %}
 </header>
 


### PR DESCRIPTION
I think the reason files are being deleted on deployment is because the Action workflow was publishing to the wrong branch (`main` instead of `gh-pages`). I think changing this, and then setting the repo's Pages setting to publish from that gh-pages branch, should take care of it.

The header tags were repeated in the /header.njk include, so I just removed the superfluous one.