### PR TITLE
Update relative links paths across site

### DIFF
--- a/docs/about-funding-public-safety/index.html
+++ b/docs/about-funding-public-safety/index.html
@@ -28,13 +28,13 @@
           <a class="nav-link" href="/funding-public-safety/about-measure-z">Measure Z</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/program-impacts">Program Impacts</a>
+          <a class="nav-link" href="/funding-public-safety/program-impacts">Program Impacts</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/get-involved">Get Involved</a>
+          <a class="nav-link" href="/funding-public-safety/get-involved">Get Involved</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/about-funding-public-safety">About FPS</a>
+          <a class="nav-link" href="/funding-public-safety/about-funding-public-safety">About FPS</a>
         </li>
       </ul>
     </div>
@@ -52,7 +52,7 @@
     <main>
       <h1 class="main-page"></h1>
       <p><em>Funding Public Safety</em> explores how Oakland spends Measure Z’s approximately $24 million annual budget, so Oaklanders can better understand the City’s approach to public safety and violence prevention. We strive to take a participatory approach to uncovering and answering the questions Oaklanders have about these deeply complex issues. <em>Funding Public Safety</em> is a project of <a href="https://openoakland.org">OpenOakland</a>, a volunteer collective that bridges community and technology for a thriving and equitable Oakland.</p>
-<p><a class="btn btn-primary" href="/get-involved" role="button">Get Involved</a></p>
+<p><a class="btn btn-primary" href="/funding-public-safety/get-involved" role="button">Get Involved</a></p>
 <h2>Process to date</h2>
 <p>In 2021, members of Measure Z’s oversight commission (the <a href="https://www.oaklandca.gov/boards-commissions/public-safety-and-services-violence-prevention-oversight-commission">SSOC</a>) asked OpenOakland to help make sense of the many evaluation reports provided by the City of Oakland. Over the course of a few months, our team gathered available data, identified goals and impacted stakeholders, and worked with the SSOC to identify questions raised by the available data. On Dec. 7, 2021, the SSOC made some key funding recommendations to Oakland’s City Council.</p>
 <p>Our next phase focuses on the following steps:</p>
@@ -73,8 +73,8 @@
 <li>Jess Sand</li>
 <li>Sydney Thomas</li>
 </ul>
-<p>If you've contributed to FPS and would like to have your name listed here (or removed), please email <a href="mailto:fundingpublicsafety@openoakland.org">fundingpublicsafety@openoakland.org</a>.</p>
-<p><a class="btn btn-primary" href="/get-involved" role="button">Join Us</a></p>
+<p>If you've contributed to FPS and would like to have your name listed here (or removed), please email <a href="mailto:fundingpublicsafety@openoakland.org">fundingpublicsafety@openoakland.org</a>. You may also make the change yourself by opening a pull request on <a href="https://github.com/openoakland/funding-public-safety">GitHub</a>.</p>
+<p><a class="btn btn-primary" href="/funding-public-safety/get-involved" role="button">Join Us</a></p>
 
     </main>
 

--- a/docs/about-measure-z/index.html
+++ b/docs/about-measure-z/index.html
@@ -28,13 +28,13 @@
           <a class="nav-link" href="/funding-public-safety/about-measure-z">Measure Z</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/program-impacts">Program Impacts</a>
+          <a class="nav-link" href="/funding-public-safety/program-impacts">Program Impacts</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/get-involved">Get Involved</a>
+          <a class="nav-link" href="/funding-public-safety/get-involved">Get Involved</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/about-funding-public-safety">About FPS</a>
+          <a class="nav-link" href="/funding-public-safety/about-funding-public-safety">About FPS</a>
         </li>
       </ul>
     </div>

--- a/docs/get-involved/index.html
+++ b/docs/get-involved/index.html
@@ -28,13 +28,13 @@
           <a class="nav-link" href="/funding-public-safety/about-measure-z">Measure Z</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/program-impacts">Program Impacts</a>
+          <a class="nav-link" href="/funding-public-safety/program-impacts">Program Impacts</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/get-involved">Get Involved</a>
+          <a class="nav-link" href="/funding-public-safety/get-involved">Get Involved</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/about-funding-public-safety">About FPS</a>
+          <a class="nav-link" href="/funding-public-safety/about-funding-public-safety">About FPS</a>
         </li>
       </ul>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,13 +27,13 @@
           <a class="nav-link" href="/funding-public-safety/about-measure-z">Measure Z</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/program-impacts">Program Impacts</a>
+          <a class="nav-link" href="/funding-public-safety/program-impacts">Program Impacts</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/get-involved">Get Involved</a>
+          <a class="nav-link" href="/funding-public-safety/get-involved">Get Involved</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/about-funding-public-safety">About FPS</a>
+          <a class="nav-link" href="/funding-public-safety/about-funding-public-safety">About FPS</a>
         </li>
       </ul>
     </div>
@@ -70,7 +70,7 @@
   <div class="card text-dark bg-light mb-3" style="max-width: 18rem;">
     <img src="assets/images/FPS-Measure-Z.png" class="class="card-img-top" alt="Thumbnail of the Measure Z ballot text">
     <div class="card-body">
-    <h5 class="card-title"><a class="btn btn-primary" href="/about-measure-z/" role="button">About Measure Z</a></h5>
+    <h5 class="card-title"><a class="btn btn-primary" href="/funding-public-safety/about-measure-z" role="button">About Measure Z</a></h5>
     </div>
   </div>
 </div>
@@ -78,7 +78,7 @@
   <div class="card text-dark bg-light mb-3" style="max-width: 18rem;">
   <img src="assets/images/FPS-thumb-Burke-mural.png" class="class="card-img-top" alt="Mural by David Burke and McClymonds High School students, depicting Ja’Khi, the princess of knowledge, overlooking a block party where Oaklanders celebrate unity and change.">
       <div class="card-body">
-      <h5 class="card-title"><a class="btn btn-primary" href="/program-impacts/" role="button">Explore Program Impacts</a></h5>
+      <h5 class="card-title"><a class="btn btn-primary" href="/funding-public-safety/program-impacts/" role="button">Explore Program Impacts</a></h5>
       </div>
     </div>
 </div>
@@ -86,7 +86,7 @@
   <div class="card text-dark bg-light mb-3" style="max-width: 18rem;">
   <img src="assets/images/FPS-thumb-openoak.png" class="class="card-img-top" alt="Blue-tinged photo of several OpenOakland members working together">
       <div class="card-body">
-      <h5 class="card-title"><a class="btn btn-primary" href="/get-involved/" role="button">Get Involved in FPS</a></h5>
+      <h5 class="card-title"><a class="btn btn-primary" href="/funding-public-safety/get-involved" role="button">Get Involved in FPS</a></h5>
       </div>
     </div>
 </div>

--- a/docs/program-impacts/index.html
+++ b/docs/program-impacts/index.html
@@ -28,13 +28,13 @@
           <a class="nav-link" href="/funding-public-safety/about-measure-z">Measure Z</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/program-impacts">Program Impacts</a>
+          <a class="nav-link" href="/funding-public-safety/program-impacts">Program Impacts</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/get-involved">Get Involved</a>
+          <a class="nav-link" href="/funding-public-safety/get-involved">Get Involved</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/about-funding-public-safety">About FPS</a>
+          <a class="nav-link" href="/funding-public-safety/about-funding-public-safety">About FPS</a>
         </li>
       </ul>
     </div>

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -15,13 +15,13 @@
           <a class="nav-link" href="{{ '/about-measure-z' | url }}">Measure Z</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/program-impacts">Program Impacts</a>
+          <a class="nav-link" href="{{ '/program-impacts' | url }}">Program Impacts</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/get-involved">Get Involved</a>
+          <a class="nav-link" href="{{ '/get-involved' | url }}">Get Involved</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/about-funding-public-safety">About FPS</a>
+          <a class="nav-link" href="{{ '/about-funding-public-safety' | url }}">About FPS</a>
         </li>
       </ul>
     </div>

--- a/src/about-funding-public-safety.md
+++ b/src/about-funding-public-safety.md
@@ -9,7 +9,7 @@ eleventyNavigation:
 
 *Funding Public Safety* explores how Oakland spends Measure Z’s approximately $24 million annual budget, so Oaklanders can better understand the City’s approach to public safety and violence prevention. We strive to take a participatory approach to uncovering and answering the questions Oaklanders have about these deeply complex issues. *Funding Public Safety* is a project of [OpenOakland](https://openoakland.org), a volunteer collective that bridges community and technology for a thriving and equitable Oakland.
 
-<a class="btn btn-primary" href="/get-involved" role="button">Get Involved</a>
+<a class="btn btn-primary" href="{{ '/get-involved' | url }}" role="button">Get Involved</a>
 
 ## Process to date
 In 2021, members of Measure Z’s oversight commission (the [SSOC](https://www.oaklandca.gov/boards-commissions/public-safety-and-services-violence-prevention-oversight-commission)) asked OpenOakland to help make sense of the many evaluation reports provided by the City of Oakland. Over the course of a few months, our team gathered available data, identified goals and impacted stakeholders, and worked with the SSOC to identify questions raised by the available data. On Dec. 7, 2021, the SSOC made some key funding recommendations to Oakland’s City Council.
@@ -32,6 +32,6 @@ We’re grateful to the following contributors and consultants who have informed
 - Jess Sand
 - Sydney Thomas
 
-If you've contributed to FPS and would like to have your name listed here (or removed), please email [fundingpublicsafety@openoakland.org](mailto:fundingpublicsafety@openoakland.org).
+If you've contributed to FPS and would like to have your name listed here (or removed), please email [fundingpublicsafety@openoakland.org](mailto:fundingpublicsafety@openoakland.org). You may also make the change yourself by opening a pull request on [GitHub](https://github.com/openoakland/funding-public-safety).
 
-<a class="btn btn-primary" href="/get-involved" role="button">Join Us</a>
+<a class="btn btn-primary" href="{{ '/get-involved' | url }}" role="button">Join Us</a>

--- a/src/index.md
+++ b/src/index.md
@@ -11,7 +11,7 @@ Public safety is a common goal for any community. Yet in Oakland, a diverse city
   <div class="card text-dark bg-light mb-3" style="max-width: 18rem;">
     <img src="assets/images/FPS-Measure-Z.png" class="class="card-img-top" alt="Thumbnail of the Measure Z ballot text">
     <div class="card-body">
-    <h5 class="card-title"><a class="btn btn-primary" href="/about-measure-z/" role="button">About Measure Z</a></h5>
+    <h5 class="card-title"><a class="btn btn-primary" href="{{ '/about-measure-z' | url }}" role="button">About Measure Z</a></h5>
     </div>
   </div>
 </div>
@@ -20,7 +20,7 @@ Public safety is a common goal for any community. Yet in Oakland, a diverse city
   <div class="card text-dark bg-light mb-3" style="max-width: 18rem;">
   <img src="assets/images/FPS-thumb-Burke-mural.png" class="class="card-img-top" alt="Mural by David Burke and McClymonds High School students, depicting Ja’Khi, the princess of knowledge, overlooking a block party where Oaklanders celebrate unity and change.">
       <div class="card-body">
-      <h5 class="card-title"><a class="btn btn-primary" href="/program-impacts/" role="button">Explore Program Impacts</a></h5>
+      <h5 class="card-title"><a class="btn btn-primary" href="{{ '/program-impacts/' | url }}" role="button">Explore Program Impacts</a></h5>
       </div>
     </div>
 </div>
@@ -29,7 +29,7 @@ Public safety is a common goal for any community. Yet in Oakland, a diverse city
   <div class="card text-dark bg-light mb-3" style="max-width: 18rem;">
   <img src="assets/images/FPS-thumb-openoak.png" class="class="card-img-top" alt="Blue-tinged photo of several OpenOakland members working together">
       <div class="card-body">
-      <h5 class="card-title"><a class="btn btn-primary" href="/get-involved/" role="button">Get Involved in FPS</a></h5>
+      <h5 class="card-title"><a class="btn btn-primary" href="{{ '/get-involved' | url }}" role="button">Get Involved in FPS</a></h5>
       </div>
     </div>
 </div>


### PR DESCRIPTION
Uses an Eleventy filter on relative link paths to properly append the funding-public-safety directory prefix to all internal links. We'll need to document this in the ReadMe! 

Example: `<a class="nav-link" href="{{ '/about-measure-z' | url }}">Measure Z</a>`
