### PR TITLE
Issue 105: add contact page with link in footer

### DIFF
--- a/src/_includes/footer.njk
+++ b/src/_includes/footer.njk
@@ -9,8 +9,19 @@
         </p>
       </div>
 
-      <div style='width: 60%; max-width: 600px'>
+      <div style='width: 50%; max-width: 600px' class='mr-4'>
         <b>Funding Public Safety</b> explores how Oakland spends Measure Z's approximately $24 million annual budget, so Oaklanders can better understand the City's approach to public safety and violence prevention.
+      </div>
+
+      <div class='row no-gutters my-4'>
+        <div class='col- mr-1'>
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-envelope-fill" viewBox="0 0 16 16">
+            <path d="M.05 3.555A2 2 0 0 1 2 2h12a2 2 0 0 1 1.95 1.555L8 8.414.05 3.555ZM0 4.697v7.104l5.803-3.558L0 4.697ZM6.761 8.83l-6.57 4.027A2 2 0 0 0 2 14h12a2 2 0 0 0 1.808-1.144l-6.57-4.027L8 9.586l-1.239-.757Zm3.436-.586L16 11.801V4.697l-5.803 3.546Z"/>
+          </svg>
+        </div>
+        <div class='col-'>
+          <a href={{ 'contact-us' | relativeUrl}} class='text-reset'>Contact Us</a>
+        </div>
       </div>
 
     </div>

--- a/src/contact-us.md
+++ b/src/contact-us.md
@@ -1,0 +1,10 @@
+---
+layout: page.njk
+title: Contact Us
+---
+
+If you encountered an issue with our website or the content, please use this <a href="https://docs.google.com/forms/d/e/1FAIpQLSdQwCWTSz6yK4YBifapPwYQjyuFmv6LVapilU-Oaf7-aafsHw/viewform" target="_blank">Bug Report form</a> to let us know.
+
+Would you like to help with this project? Please fill out the interest form below.
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSdlD4y7vLti-BNnEazg0rqK2mmPaf942RXWpN6GgqiUHcdsfg/viewform?embedded=true" width="640" height="1812" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>


### PR DESCRIPTION
This is a first draft of the contact page, with link in global footer. Note that I haven't done much frontend development in the last decade... so I'm a Bootstrap hack. Totally open to being told there's a better way to accomplish things!

Contact page:
<img width="967" alt="Screen Shot 2022-03-16 at 9 33 43 AM" src="https://user-images.githubusercontent.com/53203141/158642898-1c2377c8-1f18-47fc-8a73-dd685b58312a.png">

Footer, viewed in browser:
<img width="956" alt="Screen Shot 2022-03-16 at 9 35 40 AM" src="https://user-images.githubusercontent.com/53203141/158642920-d3ae1b82-35fb-498b-a6bf-4d3b7b921217.png">

Footer, viewed in narrow browser:
<img width="371" alt="Screen Shot 2022-03-16 at 9 35 56 AM" src="https://user-images.githubusercontent.com/53203141/158642933-2bc1bc1e-0061-44d1-a481-0769631bdd6d.png">

