### PR TITLE
Add a persistent warning with bug form link

### DIFF
--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,6 +1,6 @@
 <div class='fixed-top'>
   <div class="alert alert-warning my-0 text-center" role="alert">
-    This site is a work in progress and may contain errors or bugs. <a href="https://forms.gle/hKAEcA5AU5rxJz3i7">Submit an issue</a>.
+    This site is a work in progress and may contain errors, omissions or bugs. <a href="https://forms.gle/hKAEcA5AU5rxJz3i7">Share your feedback</a>.
   </div>
   <header class="site-header my-0">
     <div class="container-fluid"> {# Apply full-width #}

--- a/src/_includes/header.njk
+++ b/src/_includes/header.njk
@@ -1,37 +1,40 @@
-<header class="site-header fixed-top">
-<div class="container-fluid"> {# Apply full-width #}
-<nav class="navbar navbar-expand-lg navbar-light">
+<div class='fixed-top'>
+  <div class="alert alert-warning my-0 text-center" role="alert">
+    This site is a work in progress and may contain errors or bugs. <a href="https://forms.gle/hKAEcA5AU5rxJz3i7">Submit an issue</a>.
+  </div>
+  <header class="site-header my-0">
+    <div class="container-fluid"> {# Apply full-width #}
+      <nav class="navbar navbar-expand-lg navbar-light">
 
-    <div class="container"> {# Center content #}
+        <div class="container">
+          {# Center content #}
 
-    <b><a class="navbar-brand" href="{{ '/' | url }}">Funding Public Safety</a></b>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
+          <b><a class="navbar-brand" href="{{ '/' | url }}">Funding Public Safety</a></b>
+          <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+          </button>
 
-    <div class="collapse navbar-collapse nav-items" id="navbarText">
-      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/about-measure-z' | url }}">About Measure Z</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/spending' | url }}">Spending</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/program-impacts' | url }}">Impacts</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/get-involved' | url }}">Get Involved</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="{{ '/about-funding-public-safety' | url }}">About FPS</a>
-        </li>
-      </ul>
+          <div class="collapse navbar-collapse nav-items" id="navbarText">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              <li class="nav-item">
+                <a class="nav-link" href="{{ '/about-measure-z' | url }}">About Measure Z</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{{ '/spending' | url }}">Spending</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{{ '/program-impacts' | url }}">Impacts</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{{ '/get-involved' | url }}">Get Involved</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{{ '/about-funding-public-safety' | url }}">About FPS</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </nav>
     </div>
-
-    </div>
-
-
-</nav>
+  </header>
 </div>
-</header>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -11,7 +11,7 @@ body {
 	height: 100vh; /* Avoid the IE 10-11 `min-height` bug. */
 	font-family: 'Open Sans', sans-serif;
 	font-size: 1.2rem;
-	padding-top: 3rem;
+	padding-top: 7rem;
 }
 
 .content {


### PR DESCRIPTION
Added the suggested text as a "warning" alert at the top of all pages. I had to increase the top padding of the body to accommodate it.

Note that I updated the indentations in the header file - apologies for the large-looking diff. 

The core update is that I made a wrapper div for "fixed-top" positioning in order to add an alert div above the header nav bar, while keeping both fixed at the top should the user scroll down. (The green header bar includes padding that I think makes the alert look strange if we just include the alert div inside the header. I actually wonder if maybe the "header" in this file should just be a normal div, because it seems like the templating system wraps it all in a 'header' tag anyway.)

Home page:
<img width="1330" alt="Screen Shot 2022-03-16 at 10 09 58 AM" src="https://user-images.githubusercontent.com/53203141/158650067-f556dbda-ff6d-48e2-9fba-9b2a788d9f6f.png">

Other pages:
<img width="1119" alt="Screen Shot 2022-03-16 at 10 09 50 AM" src="https://user-images.githubusercontent.com/53203141/158650079-b8b40c49-b75a-45af-938e-e7ed7301d8c3.png">

